### PR TITLE
Add support for encoding blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/ethereum-block",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "An implementation of the Ethereum schema for typescript",
   "main": "dist/node.js",
   "browser": {

--- a/src/block-native.c
+++ b/src/block-native.c
@@ -146,7 +146,7 @@ napi_value recover_from_address(napi_env env, napi_callback_info info) {
 
   work->transaction = (uint8_t*) malloc(length);
   memcpy(work->transaction, data, length);
-  work->transaction_size = length;;
+  work->transaction_size = length;
   memcpy(work->signature, signature, 64);
   work->recovery = recovery;
 


### PR DESCRIPTION
This PR adds support for encoding blocks from the interfaces provided in the package.

Unfortunately, some API changes had to be made to fully enable this support, hence the bump to version 2.0.0. In particular, extraData had to be changed from a string to a Buffer, and logsBloom was changed to a Buffer as well. The previous encoding types lost data on deserialization.