### PR TITLE
Fix bit width of mixhash and nonce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/ethereum-block",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An implementation of the Ethereum schema for typescript",
   "main": "dist/node.js",
   "browser": {

--- a/src/ethereum-block.ts
+++ b/src/ethereum-block.ts
@@ -406,8 +406,8 @@ export function encodeHeaderAsRLP(header: EthereumHeader): RlpList {
   asRlpList[HEADER_TIMESTAMP] =
       removeNullPrefix(toBufferBE(header.timestamp, 32));
   asRlpList[HEADER_EXTRADATA] = header.extraData;
-  asRlpList[HEADER_MIXHASH] = removeNullPrefix(toBufferBE(header.mixHash, 32));
-  asRlpList[HEADER_NONCE] = removeNullPrefix(toBufferBE(header.nonce, 32));
+  asRlpList[HEADER_MIXHASH] = toBufferBE(header.mixHash, 32);
+  asRlpList[HEADER_NONCE] = toBufferBE(header.nonce, 8);
   return asRlpList;
 }
 


### PR DESCRIPTION
Previously, the mixHash and nonce of the block when re-encoded were being erroneously truncated. This PR fixes both fields to be 32 bits and 8 bits wide, respectively.

Closes #5 