### PR TITLE
Add functions for signing transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/ethereum-block",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "An implementation of the Ethereum schema for typescript",
   "main": "dist/node.js",
   "browser": {

--- a/src/block-native.c
+++ b/src/block-native.c
@@ -171,15 +171,222 @@ napi_value recover_from_address(napi_env env, napi_callback_info info) {
   return out;
 }
 
+struct get_public_address_work {
+  uint64_t private_key[5];
+  uint32_t error;
+
+  uint64_t account[3];
+
+  napi_deferred promise;
+  napi_async_work work;
+};
+
+
+// Async completion which resolves the promise for get_public_address
+void get_public_address_complete(napi_env env, napi_status status, struct get_public_address_work* work) {
+  napi_value result;
+  status = napi_create_bigint_words(env, 0, 3, work->account, &result);
+  assert(status == napi_ok);
+
+  status = napi_resolve_deferred(env, work->promise, result);
+  assert(status == napi_ok);
+
+  status = napi_delete_async_work(env, work->work);
+  assert(status == napi_ok);
+
+  free(work);
+}
+
+// Async function which actually performs the heavy lifting for get_public_address
+void get_public_address_execute(napi_env env, struct get_public_address_work* work) {
+
+  uint32_t secp256k1_status;
+
+  secp256k1_pubkey pubkey;
+  secp256k1_status = secp256k1_ec_pubkey_create(secp256k1ctx, &pubkey, (unsigned char*) work->private_key);
+  assert(secp256k1_status != 0);
+
+  unsigned char pubkey_serialized[65];
+  size_t pubkey_serialized_length = 65;
+  secp256k1_status = secp256k1_ec_pubkey_serialize(secp256k1ctx, pubkey_serialized, &pubkey_serialized_length, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+  assert(secp256k1_status != 0);
+
+  unsigned char digest[32];
+  // The pubkey is located in bytes 1-65
+  // We'll take the keccak-256 hash and return the last 20 bytes.
+  // keccak-256: w=1600, r=1088, c=512, suffix=0
+  KeccakWidth1600_SpongeInstance sponge;
+  KeccakWidth1600_SpongeInitialize(&sponge, 1088, 512);
+  KeccakWidth1600_SpongeAbsorb(&sponge, pubkey_serialized + 1, 64);
+  KeccakWidth1600_SpongeAbsorbLastFewBits(&sponge, 0);
+  KeccakWidth1600_SpongeSqueeze(&sponge, digest, 32);
+
+  // top 4 bytes, special case
+  work->account[2] = __builtin_bswap32(*(uint32_t*)(digest + 12));
+  // remaining bytes
+  work->account[1] = __builtin_bswap64(*(uint64_t*)(digest + 16));
+  work->account[0] = __builtin_bswap64(*(uint64_t*)(digest + 24));
+}
+
+// Generate an Ethereum address from a private key
+// Using secp256k1, a valid private key is any 256-bit number other than 0
+// js arguments:
+// 0 : private key as bigint.
+napi_value get_public_address(napi_env env, napi_callback_info info) {
+  napi_value argv[1];
+  napi_status status;
+  size_t argc = 1;
+
+  status = napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  assert(status == napi_ok);
+
+  if (argc < 1) {
+    napi_throw_error(env, "EINVAL", "Too few arguments");
+    return NULL;
+  }
+
+  struct get_public_address_work* work = malloc(sizeof(struct get_public_address_work));
+
+  int sign_bit;
+  size_t word_count = 4;
+
+  status = napi_get_value_bigint_words(env, argv[0], &sign_bit, &word_count, work->private_key);
+  assert(status == napi_ok);
+
+
+  // top is temp
+  work->private_key[4] = word_count > 0 ? __builtin_bswap64(work->private_key[0]) : 0;
+  work->private_key[0] = word_count > 3 ? __builtin_bswap64(work->private_key[3]) : 0;
+  work->private_key[3] = work->private_key[4];
+  work->private_key[4] = word_count > 1 ? __builtin_bswap64(work->private_key[1]) : 0;
+  work->private_key[1] = word_count > 2 ? __builtin_bswap64(work->private_key[2]) : 0;
+  work->private_key[2] = work->private_key[4];
+
+  napi_value async_name;
+  status = napi_create_string_utf8(env, "block-native", NAPI_AUTO_LENGTH, &async_name);
+  assert(status == napi_ok);
+
+  status = napi_create_async_work(env, NULL, async_name, 
+    (napi_async_execute_callback) get_public_address_execute,  
+    (napi_async_complete_callback) get_public_address_complete,
+    (void*) work,
+    &work->work);
+  assert(status == napi_ok);
+
+  status = napi_queue_async_work(env, work->work);
+  assert(status == napi_ok);
+
+  napi_value out;
+  status = napi_create_promise(env, &work->promise, &out);
+  assert(status == napi_ok);
+  
+  return out;
+}
+
+// Sign an ethereum transaction
+napi_value sign_transaction(napi_env env, napi_callback_info info) {
+  napi_value argv[4];
+  napi_status status;
+  size_t argc = 4;
+
+  status = napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  assert(status == napi_ok);
+
+  if (argc < 4) {
+    napi_throw_error(env, "EINVAL", "Too few arguments");
+    return NULL;
+  }
+  
+  unsigned char* to_hash;
+  size_t to_hash_length;
+  status = napi_get_buffer_info(env, argv[0], (void**) &to_hash, &to_hash_length);
+  assert(status == napi_ok);
+
+  unsigned char tx_hash[32];
+  // Hash the input buffer to get the txHash
+  KeccakWidth1600_SpongeInstance sponge;
+  KeccakWidth1600_SpongeInitialize(&sponge, 1088, 512);
+  KeccakWidth1600_SpongeAbsorb(&sponge, to_hash, to_hash_length);
+  KeccakWidth1600_SpongeAbsorbLastFewBits(&sponge, 0);
+  KeccakWidth1600_SpongeSqueeze(&sponge, tx_hash, 32);
+
+  int sign_bit;
+  size_t word_count = 4;
+  uint64_t private_key[5];
+
+  status = napi_get_value_bigint_words(env, argv[1], &sign_bit, &word_count, private_key);
+  assert(status == napi_ok);
+
+  // top is temp
+  private_key[4] = word_count > 0 ? __builtin_bswap64(private_key[0]) : 0;
+  private_key[0] = word_count > 3 ? __builtin_bswap64(private_key[3]) : 0;
+  private_key[3] = private_key[4];
+  private_key[4] = word_count > 1 ? __builtin_bswap64(private_key[1]) : 0;
+  private_key[1] = word_count > 2 ? __builtin_bswap64(private_key[2]) : 0;
+  private_key[2] = private_key[4];
+
+
+  // Sign the input buffer
+  secp256k1_ecdsa_recoverable_signature signature;
+
+  uint32_t secp256k1_status;
+  secp256k1_status = secp256k1_ecdsa_sign_recoverable(secp256k1ctx, &signature, tx_hash, (unsigned char*) private_key, NULL, NULL);
+  assert(secp256k1_status != 0);
+
+  unsigned char output[64];
+  int recovery;
+  secp256k1_status = secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1ctx, output, &recovery, &signature);
+  assert(secp256k1_status != 0);
+
+  napi_value buffer_v;
+  void* raw_v;
+  napi_value buffer_r;
+  void* raw_r;
+  napi_value buffer_s;
+  void* raw_s;
+
+  status = napi_create_buffer_copy(env, 32, output, &raw_r, &buffer_r);
+  assert(status == napi_ok);
+
+  status = napi_create_buffer_copy(env, 32, output + 32, &raw_s, &buffer_s);
+  assert(status == napi_ok);
+
+
+  uint32_t chain_id;
+  status = napi_get_value_uint32(env, argv[2], &chain_id);
+  assert(status == napi_ok);
+
+  unsigned char v = chain_id == 0 ? recovery + 27 : recovery + (chain_id * 2 + 35);
+  status = napi_create_buffer_copy(env, 1, &v, &raw_v, &buffer_v);
+  assert(status == napi_ok);
+
+  status = napi_set_element(env, argv[3], 6, buffer_v);
+  assert(status == napi_ok);
+
+  status = napi_set_element(env, argv[3], 7, buffer_r);
+  assert(status == napi_ok);
+
+  status = napi_set_element(env, argv[3], 8, buffer_s);
+  assert(status == napi_ok);
+
+  return argv[3];
+}
+
 napi_value init_all (napi_env env, napi_value exports) {
   napi_value recover_from_address_fn;
+  napi_value get_public_address_fn;
+  napi_value sign_transaction_fn;
 
   secp256k1ctx = secp256k1_context_create(
     SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
   napi_create_function(env, NULL, 0, recover_from_address, NULL, &recover_from_address_fn);
- 
+  napi_create_function(env, NULL, 0, get_public_address, NULL, &get_public_address_fn);
+  napi_create_function(env, NULL, 0, sign_transaction, NULL, &sign_transaction_fn);
+
   napi_set_named_property(env, exports, "recoverFromAddress", recover_from_address_fn);
+  napi_set_named_property(env, exports, "getPublicAddress", get_public_address_fn);
+  napi_set_named_property(env, exports, "signTransaction", sign_transaction_fn);
 
   return exports;
 }


### PR DESCRIPTION
This PR introduces new functions for obtaining an address from a private key, and also signing transactions. Native bindings are provided. The public address generation function supports async, but the transaction signing function does not (yet).