### PR TITLE
Fix contract creation serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/ethereum-block",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An implementation of the Ethereum schema for typescript",
   "main": "dist/node.js",
   "browser": {

--- a/src/ethereum-block.ts
+++ b/src/ethereum-block.ts
@@ -474,7 +474,8 @@ export function signTransaction(
     removeNullPrefix(toBufferBE(transaction.nonce, 32)),
     removeNullPrefix(toBufferBE(transaction.gasPrice, 32)),
     removeNullPrefix(toBufferBE(transaction.gasLimit, 32)),
-    toBufferBE(transaction.to, 32),
+    transaction.to === CONTRACT_CREATION ? Buffer.from([]) :
+                                           toBufferBE(transaction.to, 32),
     removeNullPrefix(toBufferBE(transaction.value, 32)), transaction.data
   ];
   // EIP-155 transaction


### PR DESCRIPTION
Previously, passing -1 (CONTRACT_CREATION) as the to: field when serializing would result in an incorrect transaction. This PR resolves that issue by correctly inserting an empty buffer in the RLP encoding.