### PR TITLE
Fix to size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/ethereum-block",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "An implementation of the Ethereum schema for typescript",
   "main": "dist/node.js",
   "browser": {

--- a/src/ethereum-block.ts
+++ b/src/ethereum-block.ts
@@ -475,7 +475,7 @@ export function signTransaction(
     removeNullPrefix(toBufferBE(transaction.gasPrice, 32)),
     removeNullPrefix(toBufferBE(transaction.gasLimit, 32)),
     transaction.to === CONTRACT_CREATION ? Buffer.from([]) :
-                                           toBufferBE(transaction.to, 32),
+                                           toBufferBE(transaction.to, 20),
     removeNullPrefix(toBufferBE(transaction.value, 32)), transaction.data
   ];
   // EIP-155 transaction


### PR DESCRIPTION
Previously, the to size was erroneously encoded as a 32byte number.
This PR fixes the encoding so that it is a 20byte number, as required by the yellowpaper.